### PR TITLE
Add CC-BY-4.0 license header

### DIFF
--- a/62304-soup/main.md
+++ b/62304-soup/main.md
@@ -1,3 +1,24 @@
+## SPDX-License-Identifier: CC-BY-4.0
+This document is released under the **Creative Commons Attribution 4.0 International License**, available
+at https://creativecommons.org/licenses/by/4.0/legalcode. Pursuant to Section 5 of the license, please
+note that the following disclaimers apply (capitalized terms have the meanings set forth in the license).
+To the extent possible, the Licensor offers the Licensed Material as-is and as-available, and makes no
+representations or warranties of any kind concerning the Licensed Material, whether express, implied,
+statutory, or other. This includes, without limitation, warranties of title, merchantability, fitness for a
+particular purpose, non-infringement, absence of latent or other defects, accuracy, or the presence
+or absence of errors, whether or not known or discoverable. Where disclaimers of warranties are not
+allowed in full or in part, this disclaimer may not apply to You.
+
+To the extent possible, in no event will the Licensor be liable to You on any legal theory (including,
+without limitation, negligence) or otherwise for any direct, special, indirect, incidental, consequential,
+punitive, exemplary, or other losses, costs, expenses, or damages arising out of this Public License
+or use of the Licensed Material, even if the Licensor has been advised of the possibility of such
+losses, costs, expenses, or damages. Where a limitation of liability is not allowed in full or in part, this
+limitation may not apply to You.
+
+The disclaimer of warranties and limitation of liability provided above shall be interpreted in a manner
+that, to the extent possible, most closely approximates an absolute disclaimer and waiver of all liability.
+
 ## Background
 
 IEC 62304 covers “Medical device software – Software life cycle


### PR DESCRIPTION
Add CC-BY-4.0 license header to the document as per the ELISA Publishing License Policy and Guidelines.

Signed-off-by: Shuah Khan <<skhan@linuxfoundation.org>>